### PR TITLE
Added the class keyword before Rectangle and uncommented lines

### DIFF
--- a/Stuff/friends.h
+++ b/Stuff/friends.h
@@ -9,11 +9,11 @@ namespace Friends
 {
 	inline void start()
 	{
-		//Rectangle rect;
-		//rect.Print();
-		//Square square = Square(5, 99);
-		//std::cout << "Friends: " << square.ReturnX() << endl;
-		//rect.SetSide(square);
-		//rect.Print();
+		class Rectangle rect;
+		rect.Print();
+		Square square = Square(5, 99);
+		std::cout << "Friends: " << square.ReturnX() << endl;
+		rect.SetSide(square);
+		rect.Print();
 	}
 }


### PR DESCRIPTION
To fix issue Friend class example broken #2, added the class keyword before Rectangle to avoid conflict with the Rectangle function in Wingdi.h and uncommented all lines in the start function.

This is for Hacktoberfest.